### PR TITLE
parsing change + new database rule (naming of columns)

### DIFF
--- a/Python/db_adding.py
+++ b/Python/db_adding.py
@@ -13,13 +13,15 @@ import os
 #      strictly followed.                           #
 #   3. All the timeline columns must have a         #
 #      single integer in the end specifying         #
-#      the replicate                                #
-#        -i.e. X6_hpf_1                             #
+#      the replicate, preceeded by a "_".           #
+#      No more underscores must be used in the name.#
+#      For more separations, use other symbols.     #
+#        -i.e. X6.hpf_1                             #
 #   4. There must be no NAs in any identifier       #
 #      columns                                      #
 #   5. The name of the table must adhere to the     #
 #      following structure:                         #
-#        - species_datatype_(optional info)_id       #
+#        - species_datatype_(optional info)_id      #
 #      i.e. zebrafish_rnaseq_investigatorA_1        #                          
 #   6. For phosphoproteomics an additional          #
 #      identifier is needed: the peptide with the   #
@@ -29,7 +31,9 @@ import os
 #                                                   #
 #   * If any of these rules is not met for a        #
 #     table submited to the database, the app       #
-#     will most likely crash                        #                            
+#     will most likely crash. Read them carefuly    #
+#     and ensure that your database meets all the   #
+#     requirements                                  #                            
 #                                                   #
 #####################################################
 

--- a/R/BRIDGE/R/dep2_helpers.R
+++ b/R/BRIDGE/R/dep2_helpers.R
@@ -2,7 +2,7 @@
 dep2_proteomics <- function(df, tbl_name, rv) {
   unique_pg <- DEP2::make_unique(df, names = "Gene_Name", ids = "Protein_ID", delim = ";")
   ecols <- match(trimws(rv$time_cols[[tbl_name]]), colnames(unique_pg))
-  se_pg <- DEP2::make_se_parse(unique_pg, columns = ecols, mode = "char", chars = 1, remove_prefix = T, log2transform = T)
+  se_pg <- DEP2::make_se_parse(unique_pg, columns = ecols, mode = "delim", sep = "_", remove_prefix = T, log2transform = T)
   filter_pg <- DEP2::filter_se(se_pg, thr = 1, fraction = 0.3)
   norm_pg <- DEP2::normalize_vsn(filter_pg)
   diff_pg <- DEP2::test_diff(norm_pg, type = "all", fdr.type = "BH")
@@ -14,7 +14,7 @@ dep2_phosphoproteomics <- function(df, tbl_name, rv) {
   df <- df[!grepl("p0", df$pepG), ] # Remove the p0
   unique_phos <-DEP2::make_unique(df, names = "pepG", ids = "Protein_ID", delim = ";")
   ecols <- match(trimws(rv$time_cols[[tbl_name]]), colnames(unique_phos))
-  se_phos <- DEP2::make_se_parse(unique_phos, columns = ecols, mode = "char", chars = 1, remove_prefix = T, log2transform = T)
+  se_phos <- DEP2::make_se_parse(unique_phos, columns = ecols, mode = "delim", sep = "_", remove_prefix = T, log2transform = T)
   filter_phos <- DEP2::filter_se(se_phos)
   norm_phos <- DEP2::normalize_vsn(filter_phos)
   diff_phos <- DEP2::test_diff(norm_phos, type = "all", fdr.type = "BH")
@@ -27,7 +27,7 @@ dep2_rnaseq <- function(df, tbl_name, rv) {
   ecols <- match(trimws(rv$time_cols[[tbl_name]]), colnames(unique_dds))
   data_mat <- as.matrix(unique_dds[, ecols])
   rownames(data_mat) <- unique_dds$Gene_ID
-  dds <- DEP2::make_dds_parse(data_mat, mode = 'char', chars = 1)
+  dds <- DEP2::make_dds_parse(data_mat, mode = "delim", sep = "_")
   dds <- DEP2::filter_se(dds, fraction = 0.3, thr = 1)
   diff <- DEP2::test_diff_deg(dds, type = 'all')
   return(diff)

--- a/R/BRIDGE/R/heatmap_server.R
+++ b/R/BRIDGE/R/heatmap_server.R
@@ -100,8 +100,8 @@ dep_heatmap_server <- function(input, output, session, rv, cache) {
 
       dep_output <- DEP2::add_rejections(dep_output, alpha = 10^-pcut, lfc = lfcut)
       rd_names <- colnames( SummarizedExperiment::rowData(dep_output))
-      sig_cols <- grep("__significant$", rd_names, value = TRUE)
-      valid_contrasts <- sub("__significant$", "_", sig_cols)  
+      sig_cols <- grep("._significant$", rd_names, value = TRUE)
+      valid_contrasts <- sub("._significant$", "_", sig_cols)  
       #Isolate function to avoid retriggering the shiny::observe block
       isolate({ 
         rv$dep_output[[tbl_name]] <- dep_output


### PR DESCRIPTION
Basically changing the naming of all the value columns from X1_hpf_1 to X1.hpf_1 or X1hpf_1 directly, basically avoiding the specified separator (_) to appear more than once (for separating the replicate) 